### PR TITLE
Bioentities no duplicates

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -551,6 +551,7 @@ rule analytics_bioentities_mapping:
         # This could optionally be either that file or a file given with specific accessions to redo.
         # or maybe the accessions broken in chunks.
         accessions="accessions_{chunk}",
+        exp_design="update_experiment_designs/{chunk}/exp_designs_updates.txt",
         index_loaded=rules.load_species_into_bioentities_index.output.loaded
     params:
         bioentities="./",

--- a/Snakefile
+++ b/Snakefile
@@ -551,7 +551,6 @@ rule analytics_bioentities_mapping:
         # This could optionally be either that file or a file given with specific accessions to redo.
         # or maybe the accessions broken in chunks.
         accessions="accessions_{chunk}",
-        exp_design="update_experiment_designs/{chunk}/exp_designs_updates.txt",
         index_loaded=rules.load_species_into_bioentities_index.output.loaded
     params:
         bioentities="./",

--- a/Snakefile-bioentities
+++ b/Snakefile-bioentities
@@ -17,7 +17,7 @@ include: "Snakefile"
 # - bioentities_source: Path to the source bioentities folder (results of E! Update live here)
 
 def get_outputs_bioentities(wildcards):
-    print("Using target: {config['target']}")
+    print(f"Using target: {config['target']}")
     if config['target'] == "load":
         outputs = [f"{config['species']}.index.loaded",
                 "exp_designs_updates.done",

--- a/Snakefile-bioentities
+++ b/Snakefile-bioentities
@@ -25,6 +25,8 @@ def get_outputs_bioentities(wildcards):
         if 'exp_update_sync_dest' in config:
             outputs.append("sync_exp_designs.done")
         return outputs
+    elif config['target'] == "load_bioentities_only":
+        outputs = [f"{config['species']}.index.loaded"]
     elif config['target'] == "jsonl":
         return get_jsonl_paths()
 

--- a/Snakefile-bioentities
+++ b/Snakefile-bioentities
@@ -9,7 +9,7 @@ include: "Snakefile"
 # - ens_eg_version: E! or E! Genomes version
 # - wbsp_version: Wormbase version. Note that some species use both E! and Wormbase.
 # - output_dir: For outputs, this is where the JSONL will be left
-# - target: currently either "load" or "jsonl". The second one stops there and doesn't execute
+# - target: currently either "load", "jsonl" or "load_bioentities_only". The second one stops there and doesn't execute
 #     deletion and load (default: "load")
 # - atlas_exps: Usually the directory where the $ATLAS_EXPS experiments are.
 # - atlas_exp_design: Path to where the experiment designs file have been copied (from wwwdev)

--- a/Snakefile-bioentities
+++ b/Snakefile-bioentities
@@ -28,6 +28,7 @@ def get_outputs_bioentities(wildcards):
         return outputs
     elif config['target'] == "load_bioentities_only":
         outputs = [f"{config['species']}.index.loaded"]
+        return outputs
     elif config['target'] == "jsonl":
         return get_jsonl_paths()
 

--- a/Snakefile-bioentities
+++ b/Snakefile-bioentities
@@ -17,6 +17,7 @@ include: "Snakefile"
 # - bioentities_source: Path to the source bioentities folder (results of E! Update live here)
 
 def get_outputs_bioentities(wildcards):
+    print("Using target: {config['target']}")
     if config['target'] == "load":
         outputs = [f"{config['species']}.index.loaded",
                 "exp_designs_updates.done",

--- a/log_handler.py
+++ b/log_handler.py
@@ -27,8 +27,9 @@ def format_percentage(done, total):
 
 l = logging.getLogger(__name__)
 l.setLevel(logging.DEBUG)
-fh = logging.FileHandler(os.environ.get('LOG_PATH'), mode='w')
-l.addHandler(fh)
+if os.environ.get('LOG_PATH'):
+    fh = logging.FileHandler(os.environ.get('LOG_PATH'), mode='w')
+    l.addHandler(fh)
 
 reit_number=int(os.environ.get('RESTART_TIMES'))
 


### PR DESCRIPTION
This PR points to newer versions of index-gxa and index-bioentities that fixes the behaviour that deals with granular re-scheduling of individual failed studies and avoid duplications in the index-bioentities loading, which we saw in Feb/March (and has been corrected). It also adds some convenience methods for loading only bioentities and avoid re-loading analytics if not needed.