### PR TITLE
Load specific accessions

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -261,7 +261,7 @@ rule set_specific_accessions_directories_per_species:
             for expAcc in "${!reloadOrganisms[@]}"; do
                 if [ "${reloadOrganisms[$expAcc]}" = "$species" ]; then
                     echo $expAcc >> $species/species_accessions.txt
-                    exp_type=$(xpath -e 'configuration/@experimentType' | sed 's/ experimentType="\(.*\)"/\1/')
+                    exp_type=$(xpath -e 'configuration/@experimentType' "$ATLAS_EXPS/$expAcc/$expAcc-configuration.xml" | sed 's/ experimentType="\(.*\)"/\1/')
             # 2.- species_baseline_accessions.txt : all baseline accessions for that species within the original list
                     if [[ $exp_type =~ .*baseline.* ]]; then
                         echo $expAcc >> $species/species_baseline_accessions.txt

--- a/Snakefile
+++ b/Snakefile
@@ -216,9 +216,9 @@ rule get_accessions_for_species:
         exec &> "{log}"
         source {params.atlas_env_file}
 
-        psql -c "COPY (SELECT accession FROM experiment WHERE species = '{params.species}') TO STDOUT WITH NULL AS ''" \
+        psql -c "COPY (SELECT accession FROM experiment WHERE species LIKE '{params.species}%' ORDER BY load_date) TO STDOUT WITH NULL AS ''" \
              -v ON_ERROR_STOP=1 $dbConnection > {output.accessions}
-        psql -c "COPY (SELECT accession FROM experiment WHERE species = '{params.species}' AND type LIKE '%BASELINE%' ) TO STDOUT WITH NULL AS ''" \
+        psql -c "COPY (SELECT accession FROM experiment WHERE species LIKE '{params.species}%' AND type LIKE '%BASELINE%' ORDER BY load_date) TO STDOUT WITH NULL AS ''" \
              -v ON_ERROR_STOP=1 $dbConnection > {output.baseline_accessions}
         """
 


### PR DESCRIPTION
This PR aims to enable loading analytics for 1 or more studies.

- [ ] update working code from codon 
- [ ] add rule for db update. The DB update should be performed as in [atlas-web-bulk](https://github.com/ebi-gene-expression-group/atlas-web-bulk/blob/develop/docker/prepare-dev-environment/postgres/docker-compose.yml#L24-L30) which uses atlas-web-core. Probably the DB update should be one of the first rules executed by the wf (for analytics-only loading). We want to do that because previous loading for bulk in Solr 7 uses a [web call](https://github.com/ebi-gene-expression-group/atlas-prod/blob/develop/exec/reload_studies.sh#L43) that updates both Solr (done already here in Snakefile) and the DB .
- [ ] improve logic for running this wf in loading-only modes
- [ ] Ensure the rsync from `ATLAS_EXPS` is done only once (either in Jenkins  or in Snakemake)
